### PR TITLE
Fix NSN over-stripping when leading digits match the region's CC

### DIFF
--- a/Sources/PhoneNumberKit/ParseManager.swift
+++ b/Sources/PhoneNumberKit/ParseManager.swift
@@ -75,10 +75,13 @@ final class ParseManager {
             if nationalNumber.hasPrefix(String(regionMetadata.countryCode)) {
                 let potentialNationalNumber = String(nationalNumber.dropFirst(String(regionMetadata.countryCode).count))
                 
-                // Validate that removing the country code prefix leaves a valid national number
+                // Only strip the leading country code when removing it produces a valid NSN AND the
+                // as-supplied NSN does not already match — otherwise we'd incorrectly drop legitimate
+                // leading digits that happen to coincide with the region's calling code.
                 if let generalNumberDesc = regionMetadata.generalDesc,
                    regexManager.hasValue(generalNumberDesc.nationalNumberPattern),
-                   parser.isNumberMatchingDesc(potentialNationalNumber, numberDesc: generalNumberDesc) {
+                   parser.isNumberMatchingDesc(potentialNationalNumber, numberDesc: generalNumberDesc),
+                   !parser.isNumberMatchingDesc(nationalNumber, numberDesc: generalNumberDesc) {
                     
                     // Attempt to create a valid phone number with the corrected national number
                     let correctedNumberString = potentialNationalNumber

--- a/Tests/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
+++ b/Tests/PhoneNumberKitTests/PhoneNumberUtilityParsingTests.swift
@@ -451,4 +451,54 @@ final class PhoneNumberUtilityParsingTests: XCTestCase {
         XCTAssertNoThrow(try sut.parse(number, withRegion: "CA"))
         XCTAssertNoThrow(try sut.parse(number, withRegion: "US"))
     }
+
+    // MARK: - NSN whose leading digits coincide with the region's calling code
+
+    func testNSNWithLeadingCountryCodeDigitsNotStripped_VN() throws {
+        let phoneNumber = try sut.parse("848043333", withRegion: "VN")
+        XCTAssertEqual(sut.format(phoneNumber, toType: .e164), "+84848043333")
+        XCTAssertTrue(sut.isValidPhoneNumber("848043333", withRegion: "VN"))
+
+        // The CC-stripping path must still fire when the input is unambiguously
+        // international (+ prefix). Both forms should resolve to the same NSN.
+        let international = try sut.parse("+84848043333", withRegion: "VN")
+        XCTAssertEqual(international.nationalNumber, phoneNumber.nationalNumber)
+
+        // The bug originally reproduced with ignoreType: true; pin that path too.
+        let ignoringType = try sut.parse("848043333", withRegion: "VN", ignoreType: true)
+        XCTAssertEqual(sut.format(ignoringType, toType: .e164), "+84848043333")
+    }
+
+    func testNSNWithLeadingCountryCodeDigitsNotStripped_IN() throws {
+        let phoneNumber = try sut.parse("9115192229", withRegion: "IN")
+        XCTAssertEqual(sut.format(phoneNumber, toType: .e164), "+919115192229")
+        XCTAssertTrue(sut.isValidPhoneNumber("9115192229", withRegion: "IN"))
+
+        let international = try sut.parse("+919115192229", withRegion: "IN")
+        XCTAssertEqual(international.nationalNumber, phoneNumber.nationalNumber)
+    }
+
+    func testNSNWithLeadingCountryCodeDigitsNotStripped_SE() throws {
+        let phoneNumber = try sut.parse("462220000", withRegion: "SE")
+        XCTAssertEqual(sut.format(phoneNumber, toType: .e164), "+46462220000")
+        XCTAssertTrue(sut.isValidPhoneNumber("462220000", withRegion: "SE"))
+
+        let international = try sut.parse("+46462220000", withRegion: "SE")
+        XCTAssertEqual(international.nationalNumber, phoneNumber.nationalNumber)
+    }
+
+    func testNSNWithLeadingCountryCodeDigits_AdditionalRegions() throws {
+        let testCases: [(region: String, nsn: String, e164: String)] = [
+            ("CH", "415678901", "+41415678901"),
+            ("IT", "3911234567", "+393911234567"),
+            ("TH", "661234567", "+66661234567"),
+            ("KZ", "77001234567", "+77001234567")
+        ]
+        for testCase in testCases {
+            let row = "region=\(testCase.region) nsn=\(testCase.nsn)"
+            let phoneNumber = try sut.parse(testCase.nsn, withRegion: testCase.region)
+            XCTAssertEqual(sut.format(phoneNumber, toType: .e164), testCase.e164, row)
+            XCTAssertTrue(sut.isValidPhoneNumber(testCase.nsn, withRegion: testCase.region), row)
+        }
+    }
 }

--- a/Tests/PhoneNumberKitTests/PhoneNumberUtilityTests.swift
+++ b/Tests/PhoneNumberKitTests/PhoneNumberUtilityTests.swift
@@ -469,7 +469,7 @@ final class PhoneNumberUtilityTests: XCTestCase {
     }
 
     func testValidDENumbers() throws {
-        let numbers = ["491713369876", "+491713369876", "01713369876", "1713369876"]
+        let numbers = ["+491713369876", "01713369876", "1713369876"]
         try numbers.forEach {
             let phoneNumber = try sut.parse($0, withRegion: "DE")
             XCTAssertNotNil(phoneNumber)
@@ -477,6 +477,11 @@ final class PhoneNumberUtilityTests: XCTestCase {
             let formatted = sut.format(phoneNumber, toType: .e164)
             XCTAssertEqual(formatted, "+491713369876")
         }
+
+        // "491713369876" is itself a valid 12-digit German NSN — "491" is an area
+        // code (Leer, Lower Saxony), not the country code — so it must not be stripped.
+        let asNationalNumber = try sut.parse("491713369876", withRegion: "DE")
+        XCTAssertEqual(sut.format(asNationalNumber, toType: .e164), "+49491713369876")
     }
 
     func testValidITNumbers() throws {


### PR DESCRIPTION
## Why

`parse(_:withRegion:)` was stripping leading digits from VN/IN/SE national numbers when those digits happened to match the region's calling code (e.g. VN `848043333` → `+848043333` instead of `+84848043333`), producing wrong E.164 output and `isValidPhoneNumber == false` for inputs the reference Google libphonenumber accepts. The fix tightens the recovery branch so the as-supplied NSN is preferred when it already matches the region's general pattern.

This also corrects ``testValidDENumbers`` for the bare input ``"491713369876"``. The prior expected output (``+491713369876``) was a side effect of the same over-eager strip heuristic; the reference libphonenumber treats it as a valid 12-digit German fixed-line number (``491`` is the area code for Leer, Lower Saxony) and returns ``+49491713369876``. Verified via [libphonenumber.appspot.com](https://libphonenumber.appspot.com/) and ``python-phonenumbers``.

**Migration note:** consumers that relied on bare ``<CC><NSN>`` inputs (no ``+``, no leading ``0``) being auto-stripped should prepend ``+`` before parsing.

Closes #2

## Test plan

- Run ``swift test`` → expect a clean suite, including the new regression cases for VN/IN/SE and the updated DE assertion.
- Cross-check parsing of the four representative inputs (VN ``848043333``, IN ``9115192229``, SE ``462220000``, DE ``491713369876``) against https://libphonenumber.appspot.com/ → expect identical E.164 and validity.