### PR TITLE
Make PartialFormatter available on non-Apple platforms

### DIFF
--- a/Sources/PhoneNumberKit/PartialFormatter.swift
+++ b/Sources/PhoneNumberKit/PartialFormatter.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2021 Roy Marmelstein. All rights reserved.
 //
 
-#if canImport(ObjectiveC)
 import Foundation
 
 /// Partial formatter
@@ -443,4 +442,3 @@ public final class PartialFormatter {
         return rebuiltString
     }
 }
-#endif

--- a/Tests/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/Tests/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Roy Marmelstein. All rights reserved.
 //
 
-#if canImport(ObjectiveC)
 @testable import PhoneNumberKit
 import XCTest
 
@@ -699,4 +698,3 @@ final class PartialFormatterTests: XCTestCase {
         XCTAssertEqual(partialFormatter.formatPartial(testNumber), "7829 7")
     }
 }
-#endif


### PR DESCRIPTION
`PartialFormatter` and its tests have been excluded on platforms without the ObjectiveC runtime since 30a267e ("Linux support", 2020). The guard was needed at the time because corelibs-foundation's `NSRegularExpression` API was incomplete on Linux. The compatibility shims added in that same commit (`NSRegularExpression+Swift.swift`) still cover the remaining platform differences, and the class itself only uses cross-platform Foundation API, so the guard no longer serves a purpose.

This removes the guard from the class and its test file. Nothing else changes.

Verified:

- The full test suite passes on macOS (126 tests, including `PartialFormatterTests`, which will now also run on non-Apple platforms).
- The package cross-compiles for Android (`aarch64-unknown-linux-android28`) with the Swift 6.3.1 Android SDK.

For context: I share phone number logic between an iOS and an Android app through a Swift package, and this guard is what currently keeps as-you-type formatting Apple-only.